### PR TITLE
Review package setup and move from distutils to setuptools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
+__pycache__/
 /.env
-/.version
 /MANIFEST
+/_meta.py
 /build/
 /dist/
 /rklib/__init__.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,8 @@
-include .version
+include CHANGES.rst
 include LICENSE.txt
 include MANIFEST.in
 include README.rst
+include _meta.py
+include tests/conftest.py
 include tests/pytest.ini
 include tests/test_*.py

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,16 @@ sdist:
 
 clean:
 	rm -rf build
+	rm -rf __pycache__
 
 distclean: clean
-	rm -f MANIFEST .version
+	rm -f MANIFEST _meta.py
 	rm -f rklib/__init__.py
 	rm -rf dist
+	rm -rf tests/.pytest_cache
+
+meta:
+	$(PYTHON) setup.py meta
 
 
-.PHONY: build test sdist clean distclean
+.PHONY: build test sdist clean distclean meta

--- a/README.rst
+++ b/README.rst
@@ -38,15 +38,12 @@ Optional library packages:
 Copyright and License
 ---------------------
 
-- Copyright 2017-2019
+- Copyright 2017–2019
   Helmholtz-Zentrum Berlin für Materialien und Energie GmbH
-- Copyright 2019 Rolf Krahl
+- Copyright 2019–2022 Rolf Krahl
 
-Licensed under the Apache License, Version 2.0 (the "License"); you
-may not use this file except in compliance with the License.  You may
-obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
+Licensed under the `Apache License`_, Version 2.0 (the "License"); you
+may not use this package except in compliance with the License.
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -58,3 +55,4 @@ permissions and limitations under the License.
 .. _setuptools_scm: https://github.com/pypa/setuptools_scm/
 .. _pytest: https://pytest.org/
 .. _distutils-pytest: https://github.com/RKrahl/distutils-pytest
+.. _Apache License: https://www.apache.org/licenses/LICENSE-2.0

--- a/python-rklib.spec
+++ b/python-rklib.spec
@@ -1,4 +1,4 @@
-%bcond_with tests
+%bcond_without tests
 %global distname rklib
 
 Name:		python3-%{distname}
@@ -41,7 +41,8 @@ python3 setup.py test
 
 %files
 %defattr(-,root,root)
-%doc README.rst
+%doc README.rst CHANGES.rst
+%license LICENSE.txt
 %{python3_sitelib}/*
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,11 @@ This package provides a collection of small helper functions and
 classes.
 """
 
-import distutils.command.build_py
+import setuptools
+from setuptools import setup
+import setuptools.command.build_py
 import distutils.command.sdist
-import distutils.core
-from distutils.core import setup
-import distutils.log
+from distutils import log
 from glob import glob
 from pathlib import Path
 import string
@@ -25,14 +25,14 @@ except (ImportError, LookupError):
         import _meta
         version = _meta.__version__
     except ImportError:
-        distutils.log.warn("warning: cannot determine version number")
+        log.warn("warning: cannot determine version number")
         version = "UNKNOWN"
 
 docstring = __doc__
 doclines = docstring.strip().split("\n")
 
 
-class meta(distutils.core.Command):
+class meta(setuptools.Command):
 
     description = "generate meta files"
     user_options = []
@@ -61,7 +61,7 @@ __version__ = "%(version)s"
         try:
             pkgname = self.distribution.packages[0]
         except IndexError:
-            distutils.log.warn("warning: no package defined")
+            log.warn("warning: no package defined")
         else:
             pkgdir = Path(self.package_dir.get(pkgname, pkgname))
             if not pkgdir.is_dir():
@@ -72,6 +72,9 @@ __version__ = "%(version)s"
             print(self.meta_template % values, file=f)
 
 
+# Note: Do not use setuptools for making the source distribution,
+# rather use the good old distutils instead.
+# Rationale: https://rhodesmill.org/brandon/2009/eby-magic/
 class sdist(distutils.command.sdist.sdist):
     def run(self):
         self.run_command('meta')
@@ -88,7 +91,7 @@ class sdist(distutils.command.sdist.sdist):
                     outf.write(string.Template(inf.read()).substitute(subst))
 
 
-class build_py(distutils.command.build_py.build_py):
+class build_py(setuptools.command.build_py.build_py):
     def run(self):
         self.run_command('meta')
         super().run()

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ except (ImportError, LookupError):
         version = "UNKNOWN"
 
 docstring = __doc__
-doclines = docstring.strip().split("\n")
 
 
 class meta(setuptools.Command):
@@ -97,20 +96,21 @@ class build_py(setuptools.command.build_py.build_py):
         super().run()
 
 
+with Path("README.rst").open("rt", encoding="utf8") as f:
+    readme = f.read()
+
 setup(
     name = "rklib",
     version = version,
-    description = doclines[0],
-    long_description = "\n".join(doclines[2:]),
+    description = docstring.split("\n")[0],
+    long_description = readme,
+    url = "https://github.com/RKrahl/rklib",
     author = "Rolf Krahl",
     author_email = "rolf@rotkraut.de",
-    url = "https://github.com/RKrahl/rklib",
     license = "Apache-2.0",
-    requires = [],
-    packages = ["rklib"],
     classifiers = [
         "Development Status :: 1 - Planning",
-        # "Intended Audience :: ?",
+        "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
@@ -120,8 +120,12 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
-        # "Topic :: ?",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    cmdclass = dict(cmdclass, build_py=build_py, sdist=sdist, meta=meta)
+    packages = ["rklib"],
+    python_requires = ">=3.4",
+    cmdclass = dict(cmdclass, build_py=build_py, sdist=sdist, meta=meta),
 )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,5 +5,5 @@ def pytest_report_header(config):
     """Add information on the package version used in the tests.
     """
     modpath = Path(rklib.__file__).resolve().parent
-    return [ "rklib: %s" % (rklib.__version__), 
+    return [ "rklib: %s" % (rklib.__version__),
              "       %s" % (modpath)]


### PR DESCRIPTION
Review the tool chain to setup the package:
* move from `distutils` to `setuptools`,
* generate a `_meta.py` module rather than a `.version` text file to store version information,
* various changes in the tool chain.
